### PR TITLE
Update image and binary names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/appcd-dev/appcd-dist/appcd-cli:latest
+FROM ghcr.io/appcd-dev/appcd-dist/stackgen-cli:latest
 
-ENTRYPOINT ["/usr/bin/appcd"]
+ENTRYPOINT ["/usr/bin/stackgen"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please follow the steps below to setup the action:
 
 ```yaml
 - name: Generate IAC
-  uses: stackgen-dev/action@v0
+  uses: appcd-dev/action@v0
   env:
     STACKGEN_TOKEN: ${{ secrets.STACKGEN_TOKEN }}
   with:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# appCD Generative IAC
+# StackGen Generative IAC
 
-This repository contains the reusable action for the appCD Generative IAC.
+This repository contains the reusable action for the StackGen Generative IAC.
 
 ## Setup
 
 Please follow the steps below to setup the action:
 
-1. Signup for an account on [appCD](https://cloud.stackgen.com/)
-2. Setup a Personal Access Token on [appCD](https://cloud.stackgen.com/account-settings/pat/)
-3. Add the Personal Access Token as a secret in your repository with the name `APPCD_TOKEN`
+1. Signup for an account on [StackGen](https://cloud.stackgen.com/)
+2. Setup a Personal Access Token on [StackGen](https://cloud.stackgen.com/account-settings/pat/)
+3. Add the Personal Access Token as a secret in your repository with the name `STACKGEN_TOKEN`
 
 ## Inputs
 
@@ -25,9 +25,9 @@ Please follow the steps below to setup the action:
 
 ```yaml
 - name: Generate IAC
-  uses: appcd-dev/action@v0
+  uses: stackgen-dev/action@v0
   env:
-    APPCD_TOKEN: ${{ secrets.APPCD_TOKEN }}
+    STACKGEN_TOKEN: ${{ secrets.STACKGEN_TOKEN }}
   with:
     # Required inputs
     ## Cloud provider: aws, azure
@@ -45,7 +45,7 @@ Please follow the steps below to setup the action:
     ## Target compute: k8s, ecs
     ## Default: k8s
     targetCompute: 'k8s'
-    ## Cleanup: true, false: Cleanup the appCD mothership after the action
+    ## Cleanup: true, false: Cleanup the stackgen mothership after the action
     ## Default: true
     cleanup: 'true'
 ```


### PR DESCRIPTION
 **PR Summary by Typo**
------------

 **Summary**

This pull request updates the base image and entry point in the Dockerfile.

**Key Points**

1. Base image changed from `appcd-cli:latest` to `stackgen-cli:latest`.
2. Entry point modified to use `/usr/bin/stackgen` instead of `/usr/bin/appcd`. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/dev-analytics/notification?tab=codeHealth">Notification settings</a>.</h6>